### PR TITLE
ユーザー管理機能_修正4

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -20,6 +20,8 @@ class ReviewsController < ApplicationController
     @review.books_genre_id = params["booksGenreId"]
     @review.books_genre_name = params["booksGenreName"]
     @review.item_caption = params["itemCaption"]
+
+    binding.pry
     
   end
 

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -44,16 +44,16 @@
   <% @books.each do |book| %>
     <% unless @isbn_list.include?(book["Item"]["isbn"]) %>
       <div class = "index_book" >
-        <% if user_signed_in? %>
+        
           <%= link_to new_review_path(
             title: book["Item"]["title"],
             author: book["Item"]["author"],
             isbn: book["Item"]["isbn"],
             largeImageUrl: book["Item"]["largeImageUrl"],
             publisherName: book["Item"]["publisherName"],
-            books_genre_id: book["Item"]["booksGenreId"],
-            books_genre_name: book["Item"]["booksGenreName"],
-            itemCaption: book["Item"]["itemCaption"],
+            booksGenreId: book["Item"]["booksGenreId"],
+            booksGenreName: book["Item"]["booksGenreName"],
+            itemCaption: truncate(book["Item"]["itemCaption"], length: 110),
             title_query: @search_params[:title_query],
             author_query: @search_params[:author_query],
             isbn_query: @search_params[:isbn_query],
@@ -61,13 +61,10 @@
           ), class: "index_book_img_link" do %>
             <img src="<%= book["Item"]["largeImageUrl"] %>" alt="Book Cover" class="index_book_img">
           <% end %>
-        <% else %>
-          <%= link_to new_user_session_path ,class: "index_book_img_link" do %>
-            <img src="<%= book["Item"]["largeImageUrl"] %>" alt="Book Cover" class="index_book_img">
-          <% end %>
-        <% end %>
+        
+        
         <div class = "index_book_info" >
-          <% if user_signed_in? %>
+          
             <h2>
               <%= link_to book["Item"]["title"], new_review_path(
                 title: book["Item"]["title"],
@@ -75,20 +72,16 @@
                 isbn: book["Item"]["isbn"],
                 largeImageUrl: book["Item"]["largeImageUrl"],
                 publisherName: book["Item"]["publisherName"],
-                books_genre_id: book["Item"]["booksGenreId"],
-                books_genre_name: book["Item"]["booksGenreName"],
-                itemCaption: book["Item"]["itemCaption"],
+                booksGenreId: book["Item"]["booksGenreId"],
+                booksGenreName: book["Item"]["booksGenreName"],
+                itemCaption: truncate(book["Item"]["itemCaption"], length: 110),
                 title_query: @search_params[:title_query],
                 author_query: @search_params[:author_query],
                 isbn_query: @search_params[:isbn_query],
                 page: @search_params[:page]
               ),class: "index_book_link" %>
             </h2>
-          <% else %>
-            <%= link_to new_user_session_path , class: "index_book_link" do %>
-              <h2><%= book["Item"]["title"] %></h2>
-            <% end %>
-          <% end %>
+          
           <p>著者: <%= book["Item"]["author"] %></p>
           <p>出版社: <%= book["Item"]["publisherName"] %></p>
           <p>isbn: <%= book["Item"]["isbn"] %></p>


### PR DESCRIPTION
・未ログイン時、ログイン画面に遷移し、ログイン成功後に感想投稿画面に遷移するよう修正した。
・セッションのオーバーフローが起こるため、あらすじを最大110字に限定した。